### PR TITLE
Update to slint 1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,9 @@ if (NOT Slint_FOUND)
   FetchContent_Declare(
     Slint
     GIT_REPOSITORY https://github.com/slint-ui/slint.git
-    GIT_TAG release/0.3
+    # `release/1` will auto-upgrade to the latest Slint >= 1.0.0 and < 2.0.0
+    # `release/1.0` will auto-upgrade to the latest Slint >= 1.0.0 and < 1.1.0
+    GIT_TAG release/1
     SOURCE_SUBDIR api/cpp
   )
   FetchContent_MakeAvailable(Slint)


### PR DESCRIPTION
Not much to do here :-)

Obviously wait merging this at least till the `release/1` branch is set up in the slint repo.